### PR TITLE
fix(az-pipeline): remove GitVersion usage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,9 +15,6 @@ variables:
   buildConfiguration: 'Release'
 
 steps:
-- task: GitVersion@5
-  displayName: Update version
-
 - task: UseDotNet@2
   displayName: Verify .NET Version
   inputs:


### PR DESCRIPTION
Remove GitVersion usage because of a missing dependency. Wait to a new version on the marketplace to add it back again